### PR TITLE
Auto update function at message area

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     var text = message.body ? `${message.body}` :'';
     var img = message.image ? `<img src= ${message.image}>` : "";
-    var html = `<div class="message">
+    var html = `<div class="message" data-message-id= '${message.id}'>
                   <div class="message-index">
                     <div class="message-index__user">
                       ${message.user_name}
@@ -20,6 +20,34 @@ $(function(){
                 </div>`
     return html;
   }
+
+
+
+  var reloadMessages = function() {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      var href = 'api/messages#index {:format=>"json"}'
+      last_message_id = $('.message:last').data('message-id');
+      console.log(last_message_id);
+      $('.contents-messages').animate({scrollTop: $('.contents-messages')[0].scrollHeight}, 'fast');
+      $.ajax({
+        url: href,
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        var insertHTML = '';
+        messages.forEach(function(message){
+          insertHTML += buildHTML(message);
+          $('.contents-messages').append(insertHTML);
+        });
+      })
+      .fail(function() {
+        alert('自動更新できませんでした');
+      });
+    };
+  };
+
 
   $('#new_message').on('submit', function(e){
     e.preventDefault();
@@ -48,4 +76,5 @@ $(function(){
       $('.input-area__image__file').val('')
     })
   })
+  setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -27,7 +27,6 @@ $(function(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       var href = 'api/messages#index {:format=>"json"}'
       last_message_id = $('.message:last').data('message-id');
-      console.log(last_message_id);
       $('.contents-messages').animate({scrollTop: $('.contents-messages')[0].scrollHeight}, 'fast');
       $.ajax({
         url: href,

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+  # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+  # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+  # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
-  # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
-  # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
-  # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
-  json.content message.content
-  json.image message.image
-  json.created_at message.created_at
+  json.body message.body
+  json.image message.image.url
+  json.date message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message_id: "#{message.id}"}}
   .message-index
     .message-index__user
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -3,3 +3,4 @@ json.user_id  @message.user.id
 json.user_name  @message.user.name
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.image @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index,:edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
メッセージ一覧画面の自動更新機能の実装

# Why
複数人が一斉に会話する状況で非同期通信でメッセージ送信していると、自分でリロードしないと
他者のメッセージを確認することができない。　その不便さを解消するために自動更新で追加された
メッセージを読み込む。

https://gyazo.com/1e3a921ebff799650aff7251e31bed66
https://gyazo.com/5f44814ef5586c869d9d1d7357fbc3e7